### PR TITLE
Add section about using with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@
 }
 ```
 
+## Usage with Prettier
+
+If you're using this ESLint config with [Prettier](https://prettier.io), make 
+sure that you disable `arrow-body-style` rule in eslint config, because it conflicts
+with with prettier rules:
+
+```json
+"rules": {
+  "arrow-body-style": "off"
+}
+``` 
+
 **Note to maintainers**: to trigger publishing of the npm package append *\[Publish\]* to the commit message. For example:
 
 *Tweaked the rules \[Publish\]*


### PR DESCRIPTION
When use with Prettier the ESLint `arrow-body-style` rule has conflict with Prettier's rule. 

Following code:

```js
import React from 'react';

export default function() {
  return (<div>{
    [].map((_, i) => {
      return (
        <div className={'qwe'} key={i}>
          { i }
        </div>
      );
    }) // <- problem line
  }</div>)
}
```

Will be reformatted to:

```js
import React from "react";

export default function() {
  return (
    <div>
      {[].map((_, i) => (
        <div className={'qwe'} key={i}>
          { i }
        </div>
      )) // <- curly brace is missed here
    </div>
  );
}
```

To fix it you'll need to disable ESLint `arrow-body-style` rule. 
This PR adds docs section about usage with Prettier and how to disable this rule.
