### PR TITLE
chore: return non-deprecated style rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 `@jetbrains` basic and style rules<br />
 `@jetbrains/eslint-config/base` basic rules<br />
-`@jetbrains/eslint-config/style` style rules ⚠️ Deprecated <br />
+`@jetbrains/eslint-config/style` style rules<br />
 `@jetbrains/eslint-config/browser` browser rules and environment<br />
 `@jetbrains/eslint-config/es6` ES6 rules and environment, including [eslint-plugin-import](https://github.com/benmosher/eslint-plugin-import)<br /> 
 `@jetbrains/eslint-config/node` Node.js rules and environment<br />

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 const base = require('./base');
+const style = require('./style');
 
 module.exports = {
-  rules: Object.assign({}, base.rules)
+  rules: Object.assign({}, base.rules, style.rules)
 };

--- a/style.js
+++ b/style.js
@@ -1,5 +1,31 @@
-console.warn('"@jetbrains/eslint-config/style" is deprecated and will be removed in next major release');
+const { ignore, error } = require("./consts");
 
 module.exports = {
-  rules: {},
+  rules: {
+    /// Stylistic Issues
+    camelcase: error,
+    "consistent-this": [error, "this"],
+    "func-names": error,
+    "func-style": [error, "declaration", { allowArrowFunctions: true }],
+    "id-length": ignore,
+    "id-match": error,
+    "max-nested-callbacks": ignore, // useless, only function with name call
+    // 'multiline-comment-style': [error, 'bare-block'],
+    "new-cap": error,
+    "no-array-constructor": error,
+    "no-continue": ignore,
+    "no-inline-comments": ignore,
+    "no-lonely-if": error,
+    "no-negated-condition": ignore,
+    "no-nested-ternary": error,
+    "no-new-object": error,
+    "no-restricted-syntax": error,
+    "no-spaced-func": error,
+    "no-ternary": ignore,
+    "no-underscore-dangle": ignore,
+    "no-unneeded-ternary": error,
+    "one-var": [error, "never"],
+    "operator-assignment": [error, "always"],
+    "sort-vars": ignore,
+  },
 };


### PR DESCRIPTION
I made a mistake in the previous PR: not every stylistic rules should be removed. I cleared the list out of deprecated rules, while preserving still valid ones.